### PR TITLE
docs: add installation, configuration, and usage guides; rewrite README as hub page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,49 +32,29 @@ OCAP is a **game-changing** Arma 3 addon that allows serverside recording of mis
 
 ---
 
-## Running OCAP
+## Getting Started
 
-Capture automatically begins when the server reaches the configured minimum player count (see userconfig settings). The addon can also be set to automatically save the recorded when the mission is ended.
+### Installation
 
-### **Configuration**
-1. Configure `/web/setting.json` with your public-facing IP, port, and a custom secret.
-1. Configure `/addon/addons/@ocap/OcapReplaySaver2.cfg.json` with matching IP/port destination and secret.
-	> `newServerGameType` is used to "tag" uploaded recordings for better organization. this will be the default tag if one isn't provided to the ocap_fnc_exportData command in-game
-	> `traceLog` set to `1` will cause the extension to log all calls for debugging purposes
-1. Configure `/addon/userconfig/config.hpp` with desired values
-	> `ocap_minPlayerCount` determines how many players must be connected before recording begins, useful for avoiding extra recordings of test tessions
-	>
-	> `ocap_minMissionTime` determines the minimum length of a mission -- if it's shorter, the recording will not be saved
-	>
-	> `ocap_frameCaptureDelay` sets how frequently the capture of all units and vehicles is run (in seconds)
-	>
-	> `ocap_saveMissionEnded` determines whether or not the recording should be saved automatically when the [`MPEnded`](https://community.bistudio.com/wiki/Arma_3:_Mission_Event_Handlers#MPEnded) event handler fires
-	>
-	> `ocap_preferACEUnconscious` defaults true, assuming that you're using ACE Medical and their unconscious system. If you aren't, please set this to false, and we'll instead track Arma 3's vanilla revive/down system.
-	>
-	> `ocap_excludeClassFromRecord` blacklists object classnames that shouldn't be tracked by OCAP
-	>
-	> `ocap_excludeKindFromRecord` use isKindOf checking to exclude one or more hierarchies of objects from recording
-	>
-	> `ocap_excludeMarkerFromRecord` blacklists markers containing any of these strings in their name so they won't be captured -- used primarily for marker framework systems you don't want to include in recordings
-	>
-	> `ocap_trackTimes` determines whether or not periodic updates are recorded containing time data from in-world. This should be set to `true` if you run missions that use time acceleration or time skips, to ensure the accurate time is recorded rather than having inaccurate extrapolation.
-	>
-	> `ocap_trackTimeInterval` determines how often time data is saved. The default is every 10 frames, which would be 10\*ocap_frameCaptureDelay.
-	>
-	> `ocap_isDebug` will cause additional log items to be written in the 'ocaplog' files during recording. Useful for troubleshooting specific issues or getting more data on what takes place during a round.
+OCAP requires two components: the **`@ocap/` server mod** (installed on your Arma 3 server) and the **web server** (hosted separately to receive recordings and serve the playback UI).
 
-### **Installation**
+1. Download the latest release from [GitHub Releases](https://github.com/OCAP2/OCAP/releases) — choose `windows.zip` or `linux.tar.gz` to match your Arma 3 server's OS.
+2. Install `@ocap/` on your Arma 3 server as a `-serverMod`. [CBA_A3](https://steamcommunity.com/workshop/filedetails/?id=450814997) is required. Clients do not need to install anything.
+3. Deploy the web server using the binary, Docker Compose, or a Pterodactyl/Pelican panel egg.
 
-1. The `/web` folder contains the front-end playback system, the server for which can be launched using `ocap-webserver.exe` on Windows. A [Docker image](https://github.com/OCAP2/web/pkgs/container/web) is also available in the web repository and is Linux-compatible.
-1. Add a firewall rule and port-forwarding if necessary. The default port is 5000 and can be customized in `web/setting.json`.
-1. Copy the `addon/addons/@ocap` subfolder to the mod directory your Arma 3 server uses.
-1. Add the **absolute path** as a `serverMod` parameter in your server start script.
-	> for example:
-	> `... -port 2302 "-serverMod=C:\Servers\Arma 3\Mods\@ocap" -cfg=myServer.cfg...`
-1. Copy the `addon/userconfig` folder to your Arma 3 server's root directory. If a userconfig folder already exists, this will simply merge OCAP's configuration data. If not, this will create it. Doing this may change your existing file, so make a backup then load your customizations into the new format if it's changed.
+→ See the **[Installation Guide](docs/installation.md)** for step-by-step instructions.
 
-### **Terrains**
+### Configuration
+
+OCAP's settings are split across three places: in-game CBA options (addon), `ocap_recorder.cfg.json` (extension), and `setting.json` (web server). The extension and web server share a secret key that must match.
+
+→ See the **[Configuration Reference](docs/configuration.md)** for all options.
+
+### Usage
+
+For mission integration (SQF/CBA API, custom events, score counters, focus windows, admin controls) and a guide to the web playback UI, see the **[Usage Guide](docs/usage.md)**.
+
+### Terrains
 
 A long list of Arma 3 terrains, both vanilla and modded, are provided in a link at the top of this ReadMe. To use one:
 1. Download the .7zip or .zip file.
@@ -83,44 +63,6 @@ A long list of Arma 3 terrains, both vanilla and modded, are provided in a link 
 The compressed file contains a folder titled with the world name. This folder contains a set of subfolders with tiled map images & a `map.json` file inside of it. Past and future recordings uploaded to this server that were played on that terrain will now display properly. In the future, we will look to implement dynamically generated vector tiling that will greatly increase the terrain resolution at higher zooms.
 
 *If someone tried to load a recording from a session played on a terrain that wasn't installed yet, the issue may persist even after installation. To fix this, they can clear their browser cache in order to force their system to re-download the terrain tiles from the server. This will be fixed in future versions.*
-
-### **Usage**
-
-To end a mission and export capture data, call the following (server-side):
-
-```sqf
-// simple message
-["OPFOR Wins. Their enemies suffered heavy losses!"] call ocap_fnc_exportData;
-
-// includes side who won
-[east, "Their enemies suffered heavy losses!"] call ocap_fnc_exportData;
-
-// includes a specific 'tag', which will be filterable in the playback menu.
-// i.e. in playback menu, selecting "PvP" from the dropdown would make this and any other mission tagged "PvP" visible in the search
-[east, "OPFOR triumphed over their enemy!", "PvP"] call ocap_fnc_exportData;
-```
-
-**Tip:** You can use the above function in a trigger.
-e.g. Create a trigger that activates once all objectives complete. Then on activation:
-```sqf
-if (isServer) then {
-
-	// Saves and uploads the recording to your server
-	[east, "OPFOR has achieved all of their objectives!"] call ocap_fnc_exportData;
-
-	// Ends mission for everyone
-	"end1" call BIS_fnc_endMissionServer; 
-};
-```
-
-> **WARNING**
->
-> To ensure your recordings are saved and uploaded:
-> 1. The mission should be ended using a `BIS_fnc_endMission`/`BIS_fnc_endMissionServer` function and configured to auto-save, or the `ocap_fnc_exportData` function should be called prior to it ending. 
-> 1. The web server process should be running and able to accept incoming network connections.
->
-> If the web component is not running, the upload will fail and a local copy of the compressed recording will be saved. Logs are available in the `Arma 3/ocaplog` directory to troubleshoot.
-
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,296 @@
+# OCAP Configuration Reference
+
+This document covers all configuration for the three OCAP components: the Arma 3 addon, the recorder extension DLL, and the web server.
+
+---
+
+## File Placement Summary
+
+| Component | Config File | Location | Controls |
+|---|---|---|---|
+| Addon | *(none — in-game only)* | `Options > Addon Options > OCAP` | Recording behaviour, exclusions, auto-save |
+| Extension | `ocap_recorder.cfg.json` | Alongside the DLL inside `@ocap/` | Storage backend, API endpoint, log level |
+| Web server | `setting.json` | Working directory of the `ocap-webserver` binary | Listen address, authentication, database path, UI customisation |
+
+> **Important:** `setting.json` → `secret` and `ocap_recorder.cfg.json` → `api.apiKey` must be set to the same value. The extension authenticates to the web server using this shared secret.
+
+---
+
+## Addon: CBA Settings
+
+Settings are configured entirely in-game at **Options > Addon Options > OCAP**. There is no file to edit. All settings are server-side and automatically synchronised to all clients in multiplayer.
+
+Settings marked **Requires Restart** take effect only after restarting the mission.
+
+### Core
+
+| Setting (variable name) | Type | Default | Description |
+|---|---|---|---|
+| `OCAP_enabled` | Boolean | `true` | Turns on or off most recording functionality. Will not reset anything from existing session, will just stop recording most new data. Note: For record/pause switching, use the CBA events! |
+| `OCAP_isDebug` | Boolean | `false` | Enables increased logging of addon actions. |
+| `OCAP_administratorList` | Stringified array | `"[]"` | An array or server-visible variable referencing one that is a list of playerUIDs. Additional briefing diary or UI elements may be available for more accessible control over OCAP's features. Takes effect on player server connection. Format: `[]` OR `myAdminPUIDs`. Example: `"['76561198000000000', '76561198000000001']"` |
+
+### Auto-start Settings
+
+| Setting (variable name) | Type | Default | Description |
+|---|---|---|---|
+| `OCAP_settings_autoStart` | Boolean | `true` | Automatically start OCAP recordings at session start. **Requires Restart.** |
+| `OCAP_settings_minPlayerCount` | Number (1–150) | `15` | Auto-start will begin once this player count is reached. |
+
+### Capture
+
+*In-game these settings appear under the **Core** category.*
+
+| Setting (variable name) | Type | Default | Description |
+|---|---|---|---|
+| `OCAP_settings_frameCaptureDelay` | Number (0.10–10.00) | `1` | Positioning, medical status, and crew states of units and vehicles will be captured every X amount of seconds. **Requires Restart.** |
+| `OCAP_settings_preferACEUnconscious` | Boolean | `true` | If true, will check ACE3 medical status on units. If false, or ACE3 is not loaded, fall back to vanilla. |
+
+### Exclusions
+
+| Setting (variable name) | Type | Default | Description |
+|---|---|---|---|
+| `OCAP_settings_excludeClassFromRecord` | Stringified array | `"['ACE_friesAnchorBar','WeaponHolderSimulated']"` | Array of object classnames that should be excluded from recording. Use single quotes. Example: `"['ACE_friesAnchorBar']"` |
+| `OCAP_settings_excludeKindFromRecord` | Stringified array | `"['WeaponHolder']"` | Array of classnames which, along with all child classes, should be excluded from recording. Use single quotes. Example: `"['WeaponHolder']"` |
+| `OCAP_settings_excludeMarkerFromRecord` | Stringified array | `"['SystemMarker_','ACE_BFT_','RscAttribute']"` | Array of prefixes. Any markers matching these prefixes will be excluded from recording. Use single quotes. |
+
+### Extra Tracking
+
+| Setting (variable name) | Type | Default | Description |
+|---|---|---|---|
+| `OCAP_settings_trackTickets` | Boolean | `true` | Will track respawn ticket counts for missionNamespace and each playable faction every 30th frame. |
+| `OCAP_settings_trackTimes` | Boolean | `false` | Will continuously track in-game world time during a mission. Useful for accelerated/skipped time scenarios. |
+| `OCAP_settings_trackTimeInterval` | Number (5–25) | `10` | If time tracking is enabled, it will be checked every X capture frames. |
+| `OCAP_settings_trackSectors` | Boolean | `true` | Automatically record sector capture events when ModuleSector_F ownership changes. |
+
+### Save/Export Settings
+
+| Setting (variable name) | Type | Default | Description |
+|---|---|---|---|
+| `OCAP_settings_saveTag` | String | `"TvT"` | If not overridden by the `exportData` CBA event or if a mission is auto-saved, this will be used to categorize and filter the recording in the database and web list of missions. |
+| `OCAP_settings_saveMissionEnded` | Boolean | `true` | If true, automatically save and export the mission when the MPEnded event fires. |
+| `OCAP_settings_saveOnEmpty` | Boolean | `true` | Will automatically save recording when there are 0 players on the server and existing data accounts for more time than the minimum save duration setting. |
+| `OCAP_settings_minMissionTime` | Number (1–120 min) | `20` | A recording must be at least this long (in minutes) to auto-save. Calling an `ocap_exportData` CBA server event will override this restriction. **Requires Restart.** |
+
+---
+
+## Extension: `ocap_recorder.cfg.json`
+
+Place this file alongside the DLL inside the `@ocap/` mod directory. Copy from `ocap_recorder.cfg.json.example` and adjust for your environment.
+
+```json
+{
+  "logLevel": "info",
+  "logsDir": "./ocaplogs",
+  "defaultTag": "TvT",
+  "api": {
+    "serverUrl": "http://127.0.0.1:5000",
+    "apiKey": "same-secret",
+    "uploadTimeout": "10m"
+  },
+  "storage": {
+    "type": "memory",
+    "memory": {
+      "outputDir": "./recordings",
+      "compressOutput": true
+    },
+    "sqlite": {
+      "dumpInterval": "3m"
+    },
+    "postgres": {
+      "host": "127.0.0.1",
+      "port": "5432",
+      "username": "postgres",
+      "password": "postgres",
+      "database": "ocap"
+    }
+  }
+}
+```
+
+### Top-level fields
+
+| Field | Default | Description |
+|---|---|---|
+| `logLevel` | `"info"` | Log verbosity. One of `debug`, `info`, `warn`, `error`. |
+| `logsDir` | `"./ocaplogs"` | Directory where log files are written. |
+| `defaultTag` | `"TvT"` | Default mission type tag used when no tag is provided by the addon at save time. |
+
+### `api`
+
+| Field | Default | Description |
+|---|---|---|
+| `serverUrl` | `"http://127.0.0.1:5000"` | Base URL of the OCAP web server that will receive uploaded recordings. |
+| `apiKey` | `"same-secret"` | Shared secret used to authenticate uploads to the web server. Must match `setting.json` → `secret`. |
+| `uploadTimeout` | `"10m"` | Maximum time to wait for an upload to complete before aborting. |
+
+### `storage.type`
+
+Controls which storage backend is used. Allowed values:
+
+| Value | Description |
+|---|---|
+| `memory` | Records entirely in memory and exports gzipped JSON files on mission end. |
+| `sqlite` | Uses an in-memory SQLite database with periodic disk dumps. |
+| `postgres` | Persists data to a PostgreSQL database. |
+| `websocket` | Streams recording data in real time to the OCAP web server. |
+
+### `storage.memory`
+
+Active when `storage.type` is `"memory"`.
+
+| Field | Default | Description |
+|---|---|---|
+| `outputDir` | `"./recordings"` | Directory where exported JSON recording files are written. |
+| `compressOutput` | `true` | Whether to gzip-compress exported recording files. |
+
+### `storage.sqlite`
+
+Active when `storage.type` is `"sqlite"`.
+
+| Field | Default | Description |
+|---|---|---|
+| `dumpInterval` | `"3m"` | How often the in-memory SQLite database is flushed to disk. |
+
+### `storage.postgres`
+
+Active when `storage.type` is `"postgres"`.
+
+| Field | Default | Description |
+|---|---|---|
+| `host` | `"127.0.0.1"` | PostgreSQL server hostname or IP. |
+| `port` | `"5432"` | PostgreSQL server port. |
+| `username` | `"postgres"` | Database user. |
+| `password` | `"postgres"` | Database password. |
+| `database` | `"ocap"` | Database name. |
+
+---
+
+## Web Server: `setting.json`
+
+Place this file in the working directory of the `ocap-webserver` binary. Copy from `setting.json.example` and adjust for your environment.
+
+Any field can be overridden via an `OCAP_<KEY>` environment variable. For nested keys, uppercase and concatenate the key path (e.g. `auth.steamApiKey` becomes `OCAP_AUTH_STEAMAPIKEY`).
+
+```json
+{
+	"listen": "127.0.0.1:5000",
+	"prefixURL": "",
+	"secret": "change-me",
+	"db": "data.db",
+	"data": "data",
+	"static": "",
+	"markers": "assets/markers",
+	"ammo": "assets/ammo",
+	"fonts": "assets/fonts",
+	"maps": "maps",
+	"logger": false,
+	"customize": {
+		"disableKillCount": false,
+		"enabled": false,
+		"headerSubtitle": "",
+		"headerTitle": "",
+		"websiteLogo": "",
+		"websiteLogoSize": "32px",
+		"websiteURL": "",
+		"cssOverrides": {}
+	},
+	"conversion": {
+		"batchSize": 1,
+		"chunkSize": 300,
+		"enabled": false,
+		"interval": "5m",
+		"retryFailed": false
+	},
+	"streaming": {
+		"enabled": false,
+		"pingInterval": "30s",
+		"pingTimeout": "10s"
+	},
+	"auth": {
+		"sessionTTL": "24h",
+		"adminSteamIds": [],
+		"steamApiKey": ""
+	},
+	"httpServer": {
+		"readTimeout": "120s",
+		"readHeaderTimeout": "30s",
+		"writeTimeout": "120s",
+		"idleTimeout": "120s"
+	}
+}
+```
+
+### Core fields
+
+| Field | Default | Description |
+|---|---|---|
+| `listen` | `"127.0.0.1:5000"` | Address and port the HTTP server listens on. |
+| `prefixURL` | `""` | URL prefix for all routes. Useful when hosted behind a reverse proxy at a sub-path. |
+| `secret` | `"change-me"` | Shared secret for authenticating mission uploads from the extension. Must match `ocap_recorder.cfg.json` → `api.apiKey`. |
+| `db` | `"data.db"` | Path to the SQLite database file used for mission metadata. |
+| `data` | `"data"` | Directory where mission recording files are stored. |
+| `static` | `""` | Optional path to a custom static files directory to override the embedded frontend. |
+| `markers` | `"assets/markers"` | Directory containing unit/vehicle marker icon assets. |
+| `ammo` | `"assets/ammo"` | Directory containing ammunition/equipment icon assets. |
+| `fonts` | `"assets/fonts"` | Directory containing font assets. |
+| `maps` | `"maps"` | Directory containing map tile data. |
+| `logger` | `false` | Enable HTTP request logging. |
+
+### `auth`
+
+| Field | Default | Description |
+|---|---|---|
+| `steamApiKey` | `""` | Steam Web API key used to validate Steam OpenID logins. Required for authentication features. |
+| `adminSteamIds` | `[]` | List of Steam64 IDs that are granted administrator access. |
+| `sessionTTL` | `"24h"` | How long a user session remains valid after login. |
+
+### `conversion`
+
+Background worker that converts uploaded JSON recordings to chunked Protobuf format. This chunked format enables faster browser-side streaming by loading only the chunks needed on demand, rather than fetching the entire recording at once. Enable this worker if you want efficient playback of large recordings.
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enable the background conversion worker. |
+| `batchSize` | `1` | Number of recordings to convert per batch. |
+| `chunkSize` | `300` | Number of frames processed per conversion chunk. |
+| `interval` | `"5m"` | How often the conversion worker checks for unconverted recordings. |
+| `retryFailed` | `false` | Whether to retry recordings that previously failed conversion. |
+
+### `streaming`
+
+Real-time WebSocket streaming of live recording data to connected clients.
+
+> **Note:** For the server to actually stream data, the extension's `storage.type` must also be set to `"websocket"` in `ocap_recorder.cfg.json`.
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enable live streaming support. |
+| `pingInterval` | `"30s"` | How often the server sends WebSocket ping frames to connected clients. |
+| `pingTimeout` | `"10s"` | How long to wait for a pong response before closing the connection. |
+
+### `customize`
+
+UI customisation options shown in the web frontend.
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enable UI customisation. When false, all other `customize` fields are ignored. |
+| `headerTitle` | `""` | Custom title text shown in the site header. |
+| `headerSubtitle` | `""` | Custom subtitle text shown in the site header. |
+| `websiteURL` | `""` | URL linked from the site logo/title. |
+| `websiteLogo` | `""` | URL or path to a custom logo image. |
+| `websiteLogoSize` | `"32px"` | CSS size value for the logo image. |
+| `disableKillCount` | `false` | When true, hides kill count displays in the frontend. |
+| `cssOverrides` | `{}` | Map of CSS variable names to values for fine-grained style overrides. |
+
+### `httpServer`
+
+Timeouts for the underlying HTTP server. All values are Go duration strings (e.g. `"120s"`, `"2m"`).
+
+| Field | Default | Description |
+|---|---|---|
+| `readTimeout` | `"120s"` | Maximum duration for reading an entire request, including the body. |
+| `readHeaderTimeout` | `"30s"` | Maximum duration for reading request headers. |
+| `writeTimeout` | `"120s"` | Maximum duration before timing out a response write. |
+| `idleTimeout` | `"120s"` | Maximum time to wait for the next request on a keep-alive connection. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,3 +294,5 @@ Timeouts for the underlying HTTP server. All values are Go duration strings (e.g
 | `readHeaderTimeout` | `"30s"` | Maximum duration for reading request headers. |
 | `writeTimeout` | `"120s"` | Maximum duration before timing out a response write. |
 | `idleTimeout` | `"120s"` | Maximum time to wait for the next request on a keep-alive connection. |
+
+> **Security note:** Increasing `readTimeout` or `idleTimeout` beyond the defaults raises exposure to [Slowloris](https://en.wikipedia.org/wiki/Slowloris_(cyber_attack))-style attacks. Keep the defaults unless you have a specific reason to raise them (e.g. very large file uploads).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,293 @@
+# Installation
+
+OCAP has two parts that need to be installed:
+
+- **Arma 3 server component** — the `@ocap/` folder, which contains both the **addon** (SQF PBOs that hook into game events) and the **extension** (the native `ocap_recorder_x64.dll` / `.so` that records data). These always ship and are installed together.
+- **Web server** — receives uploaded recordings from the extension and serves the browser-based playback UI. Can run on a different machine from the Arma 3 server.
+
+Neither component is optional: the addon without the extension has nowhere to send data, and the web server without the addon receives nothing.
+
+```
+Arma 3 server
+  └── @ocap/  (addon PBOs + extension DLL/SO, loaded via -serverMod)
+        └── HTTP upload ──► web server ◄── browser playback
+```
+
+---
+
+## Downloads
+
+Download the latest release from the [OCAP2/OCAP GitHub Releases](https://github.com/OCAP2/OCAP/releases) page.
+
+| Archive | Contents | Use for |
+|---------|----------|---------|
+| `windows.zip` | `@ocap/` (PBOs + `ocap_recorder_x64.dll`) + `web/` (`ocap-webserver.exe` + assets) | Windows Arma 3 server + Windows web server |
+| `linux.tar.gz` | `@ocap/` (PBOs + `ocap_recorder_x64.so`) + `web/` (`ocap-webserver` + assets) | Linux Arma 3 server + Linux web server |
+
+If you are running the web server in Docker or on a game server panel, you only need the archive that matches your **Arma 3 server's OS** — you won't use the `web/` folder from it.
+
+### Docker images (web server only)
+
+| Image | Description |
+|-------|-------------|
+| `ghcr.io/ocap2/web:latest` | Slim — web server only |
+| `ghcr.io/ocap2/web:full` | Includes GDAL, tippecanoe, and pmtiles for server-side map terrain tile processing |
+
+Use `:full` if you want to process and host custom Arma 3 terrain tiles through the admin UI. Use `:latest` otherwise.
+
+---
+
+## Arma 3 Server: Installing the Addon and Extension
+
+This section applies regardless of which web server deployment method you choose. Complete it first.
+
+**Prerequisites:**
+- Arma 3 dedicated server (Windows or Linux)
+- [CBA_A3](https://steamcommunity.com/workshop/filedetails/?id=450814997) installed as a server mod
+
+### 1. Extract the `@ocap/` folder
+
+Extract your release archive and locate the `@ocap/` directory. It contains:
+
+```
+@ocap/
+├── addons/              # SQF PBO files (the addon)
+├── keys/                # .bikey signature key(s)
+├── ocap_recorder_x64.dll   # (Windows) the extension
+├── ocap_recorder_x64.so    # (Linux) the extension
+└── ocap_recorder.cfg.json.example
+```
+
+### 2. Place `@ocap/` on the server
+
+Copy the entire `@ocap/` folder into your server's mods directory — the same location where your other server mods live (e.g. alongside `@CBA_A3`).
+
+### 3. Install the signature key
+
+Copy all `.bikey` files from `@ocap/keys/` into the server's root `keys/` directory.
+
+> **Why:** Arma 3 signature verification requires each mod's public key to be in the server's `keys/` folder. Without this the server will reject the mod at startup.
+
+### 4. Add `@ocap` to the `-serverMod` startup parameter
+
+In your server's start script or configuration, add `@ocap` to the `-serverMod` parameter:
+
+```
+./arma3server -serverMod="@CBA_A3;@ocap" ...
+```
+
+> **`-serverMod` vs `-mod`:** `-serverMod` loads the mod only on the server. Clients do **not** need to install or download `@ocap`. If you add it to `-mod` by mistake, clients will be required to have it too.
+
+### 5. Configure the extension
+
+Copy the example config and edit it:
+
+```bash
+cp @ocap/ocap_recorder.cfg.json.example @ocap/ocap_recorder.cfg.json
+```
+
+At minimum, set:
+
+```json
+{
+  "api": {
+    "serverUrl": "http://<your-web-server-ip>:5000",
+    "apiKey": "your-shared-secret"
+  }
+}
+```
+
+The `apiKey` value must match the `secret` field in the web server's `setting.json` (or the `OCAP_SECRET` environment variable). See [Configuration Reference](configuration.md) for all options.
+
+### 6. Start the server and verify
+
+Start the Arma 3 server. In the RPT log (`.rpt` file in the server logs directory), look for lines containing `OCAP` to confirm the addon and extension initialized correctly.
+
+### BattlEye
+
+If BattlEye is enabled on your server, the extension must be whitelisted or `callExtension` calls will be silently blocked. Add an exception for `ocap_recorder_x64` in your BattlEye configuration. Refer to the [BattlEye documentation](https://www.battleye.com/) for your server's specific whitelist format.
+
+---
+
+## Web Server: Bare Metal / Binary
+
+Use this method if you are running the web server directly on a Linux or Windows host without Docker.
+
+### 1. Extract the web server files
+
+From the release archive, extract the `web/` directory. It contains:
+
+```
+web/
+├── ocap-webserver          # Linux binary (or ocap-webserver.exe on Windows)
+├── assets/
+│   ├── markers/
+│   ├── ammo/
+│   └── fonts/
+└── setting.json.example
+```
+
+### 2. Create `setting.json`
+
+```bash
+cp setting.json.example setting.json
+```
+
+Edit `setting.json` and set `secret` to the same value as `api.apiKey` in the extension's `ocap_recorder.cfg.json`:
+
+```json
+{
+  "listen": "0.0.0.0:5000",
+  "secret": "your-shared-secret"
+}
+```
+
+See [Configuration Reference](configuration.md) for all options.
+
+### 3. Run the web server
+
+**Linux:**
+```bash
+chmod +x ocap-webserver
+./ocap-webserver
+```
+
+**Windows:**
+```
+ocap-webserver.exe
+```
+
+The server listens on port `5000` by default. Visit `http://<server-ip>:5000` to confirm it is running.
+
+### 4. Run as a persistent service (Linux)
+
+Create a systemd unit to keep the server running across reboots:
+
+```ini
+# /etc/systemd/system/ocap-web.service
+[Unit]
+Description=OCAP2 Web Server
+After=network.target
+
+[Service]
+Type=simple
+User=ocap
+WorkingDirectory=/opt/ocap/web
+ExecStart=/opt/ocap/web/ocap-webserver
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now ocap-web
+```
+
+### 5. Firewall
+
+Open port `5000` (TCP) on the host firewall so that:
+- The Arma 3 server can upload recordings to the web server.
+- Players can access the playback UI in their browser.
+
+---
+
+## Web Server: Docker Compose
+
+Use this method if you are running the web server in Docker on a Linux host.
+
+### `docker-compose.yml`
+
+Create a `docker-compose.yml` file with the following contents:
+
+```yaml
+services:
+  ocap-web:
+    image: ghcr.io/ocap2/web:latest
+    restart: unless-stopped
+    ports:
+      - "5000:5000"
+    volumes:
+      - ocap_db:/var/lib/ocap/db
+      - ocap_data:/var/lib/ocap/data
+      - ocap_maps:/var/lib/ocap/maps
+    environment:
+      OCAP_SECRET: "your-shared-secret"
+      OCAP_LISTEN: "0.0.0.0:5000"
+
+volumes:
+  ocap_db:
+  ocap_data:
+  ocap_maps:
+```
+
+Set `OCAP_SECRET` to the same value as `api.apiKey` in the extension's `ocap_recorder.cfg.json`.
+
+Any `setting.json` field can be set as an environment variable using the `OCAP_` prefix with nested keys uppercased and concatenated (e.g. `auth.steamApiKey` → `OCAP_AUTH_STEAMAPIKEY`). See [Configuration Reference](configuration.md).
+
+> **Map tools:** To use the server-side map tile processing pipeline (GDAL, tippecanoe), use `ghcr.io/ocap2/web:full` instead of `:latest`.
+
+### Start the server
+
+```bash
+docker compose up -d
+docker compose logs -f   # watch startup logs
+```
+
+Visit `http://<host-ip>:5000` to confirm the server is running.
+
+### Data persistence
+
+The three named volumes store:
+
+| Volume | Contents |
+|--------|----------|
+| `ocap_db` | SQLite database (mission metadata) |
+| `ocap_data` | Uploaded recording files |
+| `ocap_maps` | Map terrain tiles |
+
+These persist across container restarts and updates. To update:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+---
+
+## Web Server: Pterodactyl / Pelican
+
+Two panel eggs are included in the web server release archive and also available in the [OCAP2/web repository](https://github.com/OCAP2/web):
+
+| File | Panel |
+|------|-------|
+| `egg-ocap2-web.json` | [Pelican Panel](https://pelican.dev/) (PLCN_v3) |
+| `egg-ocap2-web-pterodactyl.json` | [Pterodactyl Panel](https://pterodactyl.io/) (PTDL_v2) |
+
+### 1. Import the egg
+
+In your panel's admin area, navigate to **Nests** (Pterodactyl) or **Eggs** (Pelican) and import the JSON file that matches your panel version.
+
+### 2. Create a server
+
+Create a new server using the **OCAP2 Web** egg. The panel will prompt you to set the following variables:
+
+| Variable | Description |
+|----------|-------------|
+| **OCAP Secret** | Shared secret for recording uploads. Must match `api.apiKey` in the extension config. |
+| **Enable Conversion** | Enables background JSON → Protobuf conversion for faster playback. Recommended: `true`. |
+| **Enable Streaming** | Enables live WebSocket streaming from the extension. Default: `false`. |
+| **Allowed Steam IDs** | Steam 64-bit IDs (comma-separated) granted admin access to the web UI. Optional. |
+| **Steam API Key** | For displaying Steam display names in the admin UI. Optional. |
+
+The **Listen Address** and storage path variables are pre-configured and should not need to be changed.
+
+### 3. Start the server
+
+Start the server from the panel. The install script automatically creates the required data directories.
+
+Visit the server's allocated address to confirm the web UI is accessible.
+
+> **Docker image:** The egg uses `ghcr.io/ocap2/web:full` by default, which includes the map tile processing tools. To use the smaller slim image, change the Docker image in the egg or server settings to `ghcr.io/ocap2/web:latest`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,13 +62,7 @@ Extract your release archive and locate the `@ocap/` directory. It contains:
 
 Copy the entire `@ocap/` folder into your server's mods directory — the same location where your other server mods live (e.g. alongside `@CBA_A3`).
 
-### 3. Install the signature key
-
-Copy all `.bikey` files from `@ocap/keys/` into the server's root `keys/` directory.
-
-> **Why:** Arma 3 signature verification requires each mod's public key to be in the server's `keys/` folder. Without this the server will reject the mod at startup.
-
-### 4. Add `@ocap` to the `-serverMod` startup parameter
+### 3. Add `@ocap` to the `-serverMod` startup parameter
 
 In your server's start script or configuration, add `@ocap` to the `-serverMod` parameter:
 
@@ -78,7 +72,7 @@ In your server's start script or configuration, add `@ocap` to the `-serverMod` 
 
 > **`-serverMod` vs `-mod`:** `-serverMod` loads the mod only on the server. Clients do **not** need to install or download `@ocap`. If you add it to `-mod` by mistake, clients will be required to have it too.
 
-### 5. Configure the extension
+### 4. Configure the extension
 
 Copy the example config and edit it:
 
@@ -99,13 +93,15 @@ At minimum, set:
 
 The `apiKey` value must match the `secret` field in the web server's `setting.json` (or the `OCAP_SECRET` environment variable). See [Configuration Reference](configuration.md) for all options.
 
-### 6. Start the server and verify
+### 5. Start the server and verify
 
 Start the Arma 3 server. In the RPT log (`.rpt` file in the server logs directory), look for lines containing `OCAP` to confirm the addon and extension initialized correctly.
 
-### BattlEye
+### Windows: unblock the extension DLL
 
-If BattlEye is enabled on your server, the extension must be whitelisted or `callExtension` calls will be silently blocked. Add an exception for `ocap_recorder_x64` in your BattlEye configuration. Refer to the [BattlEye documentation](https://www.battleye.com/) for your server's specific whitelist format.
+When downloaded from the internet, Windows may mark `ocap_recorder_x64.dll` as blocked due to security zone policies. If the extension silently fails to load, right-click the `.dll` in Explorer, open **Properties**, and tick **Unblock** at the bottom of the General tab.
+
+> **BattlEye:** Server mods loaded via `-serverMod` bypass BattlEye entirely — no whitelisting is required.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -167,9 +167,9 @@ After=network.target
 
 [Service]
 Type=simple
-User=ocap
-WorkingDirectory=/opt/ocap/web
-ExecStart=/opt/ocap/web/ocap-webserver
+User=<user>
+WorkingDirectory=/path/to/ocap/web
+ExecStart=/path/to/ocap/web/ocap-webserver
 Restart=on-failure
 RestartSec=5
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,7 +52,7 @@ Extract your release archive and locate the `@ocap/` directory. It contains:
 ```
 @ocap/
 ├── addons/              # SQF PBO files (the addon)
-├── keys/                # .bikey signature key(s)
+├── keys/                 # not needed for -serverMod use
 ├── ocap_recorder_x64.dll   # (Windows) the extension
 ├── ocap_recorder_x64.so    # (Linux) the extension
 └── ocap_recorder.cfg.json.example
@@ -97,11 +97,11 @@ The `apiKey` value must match the `secret` field in the web server's `setting.js
 
 Start the Arma 3 server. In the RPT log (`.rpt` file in the server logs directory), look for lines containing `OCAP` to confirm the addon and extension initialized correctly.
 
-### Windows: unblock the extension DLL
+> **BattlEye:** Server mods loaded via `-serverMod` bypass BattlEye entirely — no whitelisting is required.
+
+### Windows only — if the extension fails to load
 
 When downloaded from the internet, Windows may mark `ocap_recorder_x64.dll` as blocked due to security zone policies. If the extension silently fails to load, right-click the `.dll` in Explorer, open **Properties**, and tick **Unblock** at the bottom of the General tab.
-
-> **BattlEye:** Server mods loaded via `-serverMod` bypass BattlEye entirely — no whitelisting is required.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,226 @@
+# Using OCAP
+
+OCAP has two usage layers: **mission integration** (SQF/CBA API for controlling recording from within a mission) and **playback** (the web UI for watching recordings).
+
+---
+
+## Part 1: Mission Integration
+
+### Auto-Start
+
+When `OCAP_settings_autoStart` is enabled (default), recording begins automatically after the briefing screen once the minimum player count (`OCAP_settings_minPlayerCount`, default 15) is connected. No mission-side scripting is required.
+
+When recording starts, every connected player receives a diary entry under **OCAPInfo** confirming the start time (elapsed in-mission time and UTC system time).
+
+If the minimum player count is never reached, recording does not start automatically. Use the `OCAP_record` CBA event or the admin diary controls to start it manually — see [Manual Recording Control](#manual-recording-control).
+
+See [Configuration Reference](configuration.md) for the relevant settings.
+
+### Ending a Mission and Exporting
+
+Call `OCAP_recorder_fnc_exportData` server-side to end the recording and upload it to the web server. All parameters are optional.
+
+```sqf
+// No args — records "Mission ended"
+[] call OCAP_recorder_fnc_exportData;
+
+// Winning side only
+[west] call OCAP_recorder_fnc_exportData;
+
+// Side + outcome message
+[east, "OPFOR controlled all sectors!"] call OCAP_recorder_fnc_exportData;
+
+// Side + message + tag (filterable in the recording selector)
+[east, "OPFOR controlled all sectors!", "PvP"] call OCAP_recorder_fnc_exportData;
+```
+
+**Typical trigger pattern** — create a trigger that fires when objectives are complete, then in its On Activation field:
+
+```sqf
+if (isServer) then {
+    [east, "OPFOR has achieved all of their objectives!"] call OCAP_recorder_fnc_exportData;
+    "end1" call BIS_fnc_endMissionServer;
+};
+```
+
+**Async save flow:** `OCAP_recorder_fnc_exportData` is non-blocking. Players see an interim "saving…" screen notification immediately. The extension writes and uploads the recording in the background; once it finishes, a final diary entry confirms success or failure.
+
+**Minimum duration:** Recordings shorter than the configured minimum (default 20 minutes) are not saved. If the recording is too short, export is skipped and a diary entry explains why. Recording continues, so the mission can still be saved once the threshold is met — or bypass it with the `OCAP_exportData` CBA event (see [Manual Recording Control](#manual-recording-control)).
+
+> **Note:** If `OCAP_settings_saveMissionEnded` or `OCAP_settings_saveOnEmpty` is true, `OCAP_recorder_fnc_exportData` is called automatically on the `MPEnded` event or when the server empties. See [Configuration Reference](configuration.md).
+
+### Manual Recording Control
+
+Three CBA server events let you control recording from scripts or admin diary controls. All require the caller to be a server admin or to have their Steam UID listed in `OCAP_administratorList`.
+
+| Event | Effect |
+|-------|--------|
+| `["OCAP_record"] call CBA_fnc_serverEvent;` | Start or resume recording |
+| `["OCAP_pause"] call CBA_fnc_serverEvent;` | Pause recording (data preserved; resume with `OCAP_record`) |
+| `["OCAP_exportData", [Side, String, String]] call CBA_fnc_serverEvent;` | Stop and save — **always bypasses minimum duration** |
+
+Examples:
+
+```sqf
+// Start recording manually (e.g. when a specific mission phase begins)
+["OCAP_record"] call CBA_fnc_serverEvent;
+
+// Pause recording (e.g. during a long mid-mission briefing)
+["OCAP_pause"] call CBA_fnc_serverEvent;
+
+// Force-save with side and message, ignoring minimum duration
+["OCAP_exportData", [west, "BLUFOR completed the objectives!", "TvT"]] call CBA_fnc_serverEvent;
+```
+
+**When to use CBA events vs. `OCAP_recorder_fnc_exportData`:**
+- Use `OCAP_recorder_fnc_exportData` in normal mission-end triggers — it respects minimum duration and is the standard mission-end path.
+- Use the `OCAP_exportData` CBA event when you need to force-save regardless of duration (admin manual export, server restart).
+- Use `OCAP_record` / `OCAP_pause` to gate recording around specific phases (e.g. don't record while players are slotting in).
+
+### Custom Events
+
+Fire custom events from any server-side script to add entries to the Events tab in the playback UI.
+
+**General event** — freeform text entry:
+```sqf
+["OCAP_customEvent", ["generalEvent", "Player reached the extraction zone"]] call CBA_fnc_serverEvent;
+```
+
+**Sector captured** — structured event with sector name, owning side, and world position:
+```sqf
+["OCAP_customEvent", ["captured", ["sector", "Sector Alpha", str west, getPosASL _sector]]] call CBA_fnc_localEvent;
+```
+
+**Sector contested** — sector is being fought over (no owning side yet):
+```sqf
+["OCAP_customEvent", ["contested", ["sector", "Sector Alpha", "", getPosASL _sector]]] call CBA_fnc_localEvent;
+```
+
+**End mission event** — log a mission-end message as a timeline event (separate from `OCAP_recorder_fnc_exportData`):
+```sqf
+// With winning side
+["OCAP_customEvent", ["endMission", [str west, "BLUFOR controlled all sectors!"]]] call CBA_fnc_localEvent;
+
+// Message only
+["OCAP_customEvent", ["endMission", "Mission complete!"]] call CBA_fnc_localEvent;
+```
+
+> See the [OCAP wiki](https://github.com/OCAP2/OCAP/wiki/Custom-Game-Events) for extended custom event documentation.
+
+### Score Counters
+
+Track side-specific scores or ticket counts. Values appear as a live counter overlay in the playback UI.
+
+Initialize once at mission start:
+```sqf
+["OCAP_counterInit", [
+    [west, 0],
+    [east, 0]
+]] call CBA_fnc_serverEvent;
+```
+
+Update whenever the score changes:
+```sqf
+// Set BLUFOR score to 3
+["OCAP_counterEvent", [west, 3]] call CBA_fnc_serverEvent;
+```
+
+This system is independent of `BIS_fnc_respawnTickets`. Wire it to whatever scoring or ticket logic your mission uses.
+
+### Focus Windows
+
+Mark a sub-range of the recording as the key phase. The focused range is highlighted on the timeline scrubber in the playback UI.
+
+Set the in-point at the current capture frame:
+```sqf
+["OCAP_setFocusStart"] call CBA_fnc_serverEvent;
+```
+
+Set the out-point at the current capture frame:
+```sqf
+["OCAP_setFocusEnd"] call CBA_fnc_serverEvent;
+```
+
+Or specify explicit frame numbers:
+```sqf
+["OCAP_setFocusStart", [120]] call CBA_fnc_serverEvent;
+["OCAP_setFocusEnd", [850]] call CBA_fnc_serverEvent;
+```
+
+The focus range can also be set interactively in the playback UI using the `I` and `O` keyboard shortcuts — see [Focus Mode](#focus-mode) in the Playback section below.
+
+### Admin Controls (In-Game Diary)
+
+Players who are server admins, or whose Steam UID is in `OCAP_administratorList`, automatically receive an **OCAP Admin** tab in their briefing diary. It provides three clickable controls:
+
+- **Start/Resume Recording** — fires `OCAP_record`
+- **Pause Recording** — fires `OCAP_pause`
+- **Stop and Export Recording** — fires `OCAP_exportData`, bypassing minimum duration
+
+The tab is added on player connect and removed if the player logs out of admin. No mission-side scripting is needed — set `OCAP_administratorList` in CBA settings to grant specific UIDs access regardless of admin status.
+
+---
+
+## Part 2: Playback
+
+### Finding a Recording
+
+Navigate to the web server address in any browser. The recording selector lists all uploaded missions with their name, upload date, and tag.
+
+- Use the **search box** to filter by mission name.
+- Use the **tag dropdown** to filter by tag (set via `OCAP_recorder_fnc_exportData` or `OCAP_settings_saveTag`).
+- Use the **map filter** to narrow by terrain or world name.
+
+Click any recording to open it in the playback view.
+
+### Playback Controls
+
+The bottom bar contains the main controls:
+
+- **Play/Pause button** — starts or stops playback.
+- **Timeline scrubber** — click or drag to jump to any point in the recording. If a focus range was set, it is highlighted on the scrubber.
+
+### Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Space` | Toggle play/pause |
+| `E` | Toggle side panel visibility |
+| `←` / `→` | Step back / forward 1 frame |
+| `Shift+←` / `Shift+→` | Step back / forward 10 frames |
+| `,` | Jump to previous kill event |
+| `.` | Jump to next kill event |
+| `I` | Set focus in-point (focus edit mode only) |
+| `O` | Set focus out-point (focus edit mode only) |
+| `Escape` | Cancel focus edit |
+
+### Following a Unit
+
+Click any unit icon on the map to lock the camera to that unit. The map pans to keep the unit centered as the recording plays. A follow indicator appears in the UI. Click the map background or a different unit to change or release the follow lock.
+
+### Side Panel
+
+The side panel on the left has three tabs. Press `E` to hide it and maximize the map view.
+
+**Units** — all players, AI, and vehicles in the mission. Shows alive/dead state, group name, and slotted role. Click a unit to follow them on the map.
+
+**Events** — a chronological, filterable log of game events: kills, deaths, hits, player connects/disconnects, and any custom events fired via `OCAP_customEvent`. Click any event to jump to that frame. Use the filter controls to show or hide event types (e.g. hide hits to reduce noise).
+
+**Stats** — kill counts and mission summary statistics.
+
+### Focus Mode
+
+To set a focus range interactively while watching a recording:
+
+1. Click the focus toolbar button to enter focus edit mode.
+2. Navigate to the desired start point, then press `I`.
+3. Navigate to the desired end point, then press `O`.
+4. Press `Escape` to cancel without saving.
+
+The focus range is a visual highlight on the timeline — it does not trim the recording.
+
+If the mission set a focus range server-side via `OCAP_setFocusStart` / `OCAP_setFocusEnd`, it appears automatically when you open the recording.
+
+### Counter Display
+
+If the mission used `OCAP_counterInit`, a score counter appears on-screen during playback showing the tracked values for each side as they changed over time.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -88,21 +88,21 @@ Fire custom events from any server-side script to add entries to the Events tab 
 
 **Sector captured** — structured event with sector name, owning side, and world position:
 ```sqf
-["OCAP_customEvent", ["captured", ["sector", "Sector Alpha", str west, getPosASL _sector]]] call CBA_fnc_localEvent;
+["OCAP_customEvent", ["captured", ["sector", "Sector Alpha", str west, getPosASL _sector]]] call CBA_fnc_serverEvent;
 ```
 
 **Sector contested** — sector is being fought over (no owning side yet):
 ```sqf
-["OCAP_customEvent", ["contested", ["sector", "Sector Alpha", "", getPosASL _sector]]] call CBA_fnc_localEvent;
+["OCAP_customEvent", ["contested", ["sector", "Sector Alpha", "", getPosASL _sector]]] call CBA_fnc_serverEvent;
 ```
 
 **End mission event** — log a mission-end message as a timeline event (separate from `OCAP_recorder_fnc_exportData`):
 ```sqf
 // With winning side
-["OCAP_customEvent", ["endMission", [str west, "BLUFOR controlled all sectors!"]]] call CBA_fnc_localEvent;
+["OCAP_customEvent", ["endMission", [str west, "BLUFOR controlled all sectors!"]]] call CBA_fnc_serverEvent;
 
 // Message only
-["OCAP_customEvent", ["endMission", "Mission complete!"]] call CBA_fnc_localEvent;
+["OCAP_customEvent", ["endMission", "Mission complete!"]] call CBA_fnc_serverEvent;
 ```
 
 > See the [OCAP wiki](https://github.com/OCAP2/OCAP/wiki/Custom-Game-Events) for extended custom event documentation.


### PR DESCRIPTION
## Summary

This PR adds three new documentation files and rewrites the README to serve as a clean hub page linking out to them. The goal is to replace the outdated, hard-to-maintain inline docs with structured, accurate references that reflect the current state of the project.

### What changed

**New files:**
- `docs/installation.md` — complete installation guide covering all deployment methods: bare metal binary (Linux + Windows, with systemd unit example), Docker Compose (with working `docker-compose.yml`), and Pterodactyl/Pelican panel (with egg import steps and variable reference table). Includes Arma 3 server setup (addon placement, bikey installation, `-serverMod` guidance, BattlEye note) and a component overview diagram.
- `docs/configuration.md` — full configuration reference for all three OCAP components: addon CBA settings (18 settings across 6 categories), extension `ocap_recorder.cfg.json` (all fields including storage backends: memory, sqlite, postgres, websocket), and web server `setting.json` (all fields including auth, conversion, streaming, customize, httpServer sections, with env var override documentation).
- `docs/usage.md` — usage guide in two parts: (1) mission integration covering the SQF/CBA API (`ocap_fnc_exportData`, `OCAP_record`/`OCAP_pause`/`OCAP_exportData` events, custom events, score counters, focus windows, admin diary controls), and (2) playback UI covering the recording selector, keyboard shortcuts, unit following, side panel tabs, focus mode, and counter display.

**Updated files:**
- `README.md` — rewritten as a hub page. The outdated "Running OCAP" section (which referenced `OcapReplaySaver2.cfg.json` and `userconfig/config.hpp`, neither of which exist in the current codebase) has been removed and replaced with a "Getting Started" section containing a 3-step install summary and links to all three new docs. All existing prose (feature overview, detailed features, developers, credits) is preserved verbatim.

### Why

The previous README contained configuration instructions referencing files that no longer exist (`OcapReplaySaver2.cfg.json`, `userconfig/config.hpp`) — the extension config was renamed and addon settings moved to the CBA in-game system. New users following those instructions would be unable to configure OCAP correctly.

The new docs are sourced directly from the current codebase:
- Extension config fields from `extension/ocap_recorder.cfg.json.example`
- Web server config from `web/setting.json.example`
- Addon CBA settings from `addon/addons/main/XEH_preInit.sqf` and `addon/addons/recorder/XEH_preInit.sqf`
- CBA event names and parameters from `addon/addons/recorder/fnc_addEventMission.sqf` and `fnc_handleCustomEvent.sqf`
- Docker volume paths from `web/Dockerfile`
- Panel egg variables from `web/egg-ocap2-web.json` and `web/egg-ocap2-web-pterodactyl.json`
- Keyboard shortcuts from `web/ui/src/pages/recording-playback/shortcuts.ts`

## Test plan

- [ ] Verify `docs/installation.md` renders correctly on GitHub — check tables, code blocks, ASCII diagram
- [ ] Verify `docs/configuration.md` renders correctly — check all tables and JSON example blocks
- [ ] Verify `docs/usage.md` renders correctly — check SQF code blocks and keyboard shortcuts table
- [ ] Verify all relative links in README (`docs/installation.md`, `docs/configuration.md`, `docs/usage.md`) resolve correctly on GitHub
- [ ] Confirm `OcapReplaySaver2`, `userconfig`, and `Running OCAP` no longer appear in README