### PR TITLE
docs: clarify some points in the guides for first-time setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ For mission integration (SQF/CBA API, custom events, score counters, focus windo
 
 ### Terrains
 
-A long list of Arma 3 terrains, both vanilla and modded, are provided in a link at the top of this ReadMe. To use one:
-1. Download the .7zip or .zip file.
+We host a long list of Arma 3 terrains, both vanilla and modded, on our CDN for the web playback UI. You do not need to download any of our map tiles, but if it is preferred, you can:
+1. Download the .7z from [Google Drive](https://drive.google.com/drive/folders/1qtT0Fr4Dfwd48ihZNc8YN-xgxHchKoiu).
 1. Extract the contents to your `web/maps` folder or Docker volume.
 
 The compressed file contains a folder titled with the world name. This folder contains a set of subfolders with tiled map images & a `map.json` file inside of it. Past and future recordings uploaded to this server that were played on that terrain will now display properly. In the future, we will look to implement dynamically generated vector tiling that will greatly increase the terrain resolution at higher zooms.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,7 +242,7 @@ Any field can be overridden via an `OCAP_<KEY>` environment variable. For nested
 | Field | Default | Description |
 |---|---|---|
 | `steamApiKey` | `""` | Steam Web API key used to validate Steam OpenID logins. Required for authentication features. |
-| `adminSteamIds` | `[]` | List of Steam64 IDs that are granted administrator access. |
+| `adminSteamIds` | `[]` | List of Steam64 IDs that are granted administrator access (comma-separated in env var). |
 | `sessionTTL` | `"24h"` | How long a user session remains valid after login. |
 
 ### `conversion`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,7 @@ Place this file alongside the DLL inside the `@ocap/` mod directory. Copy from `
 
 | Field | Default | Description |
 |---|---|---|
-| `serverUrl` | `"http://127.0.0.1:5000"` | Base URL of the OCAP web server that will receive uploaded recordings. |
+| `serverUrl` | `"http://127.0.0.1:5000"` | Base URL of the OCAP web server that will receive uploaded recordings. If [`prefixUrl`](#core-fields) is used, this URL should match it, e.g. `"http://127.0.0.1:5000/ocap"`. |
 | `apiKey` | `"same-secret"` | Shared secret used to authenticate uploads to the web server. Must match `setting.json` → `secret`. |
 | `uploadTimeout` | `"10m"` | Maximum time to wait for an upload to complete before aborting. |
 
@@ -226,7 +226,7 @@ Any field can be overridden via an `OCAP_<KEY>` environment variable. For nested
 | Field | Default | Description |
 |---|---|---|
 | `listen` | `"127.0.0.1:5000"` | Address and port the HTTP server listens on. |
-| `prefixURL` | `""` | URL prefix for all routes. Useful when hosted behind a reverse proxy at a sub-path. |
+| `prefixURL` | `""` | URL prefix for all routes, e.g. `"/ocap"`. Useful when hosted behind a reverse proxy at a sub-path. Must be appended to `ocap_recorder.cfg.json` → [`api.serverUrl`](#api). |
 | `secret` | `"change-me"` | Shared secret for authenticating mission uploads from the extension. Must match `ocap_recorder.cfg.json` → `api.apiKey`. |
 | `db` | `"data.db"` | Path to the SQLite database file used for mission metadata. |
 | `data` | `"data"` | Directory where mission recording files are stored. |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,7 @@ If you are running the web server in Docker or on a game server panel, you only 
 | `ghcr.io/ocap2/web:latest` | Slim — web server only |
 | `ghcr.io/ocap2/web:full` | Includes GDAL, tippecanoe, and pmtiles for server-side map terrain tile processing |
 
-Use `:full` if you want to process and host custom Arma 3 terrain tiles through the admin UI. Use `:latest` otherwise.
+Use `:full` if you have grad_meh exports that you want to import in the admin UI. Use `:latest` otherwise. You only need `:latest` to locally host map tiles such as those from [Google Drive](https://drive.google.com/drive/folders/1qtT0Fr4Dfwd48ihZNc8YN-xgxHchKoiu).
 
 ---
 
@@ -223,7 +223,7 @@ Set `OCAP_SECRET` to the same value as `api.apiKey` in the extension's `ocap_rec
 
 Any `setting.json` field can be set as an environment variable using the `OCAP_` prefix with nested keys uppercased and concatenated (e.g. `auth.steamApiKey` → `OCAP_AUTH_STEAMAPIKEY`). See [Configuration Reference](configuration.md).
 
-> **Map tools:** To use the server-side map tile processing pipeline (GDAL, tippecanoe), use `ghcr.io/ocap2/web:full` instead of `:latest`.
+> **Map tools:** To use the server-side pipeline for for processing grad-meh exports into map tiles (GDAL, tippecanoe), choose `ghcr.io/ocap2/web:full` instead of `:latest`.
 
 ### Start the server
 
@@ -286,4 +286,4 @@ Start the server from the panel. The install script automatically creates the re
 
 Visit the server's allocated address to confirm the web UI is accessible.
 
-> **Docker image:** The egg uses `ghcr.io/ocap2/web:full` by default, which includes the map tile processing tools. To use the smaller slim image, change the Docker image in the egg or server settings to `ghcr.io/ocap2/web:latest`.
+> **Docker image:** The egg uses `ghcr.io/ocap2/web:full` by default, which includes the tools needed to process grad_meh exports into map tiles. To use the smaller slim image, change the Docker image in the egg or server settings to `ghcr.io/ocap2/web:latest`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -223,7 +223,7 @@ Set `OCAP_SECRET` to the same value as `api.apiKey` in the extension's `ocap_rec
 
 Any `setting.json` field can be set as an environment variable using the `OCAP_` prefix with nested keys uppercased and concatenated (e.g. `auth.steamApiKey` → `OCAP_AUTH_STEAMAPIKEY`). See [Configuration Reference](configuration.md).
 
-> **Map tools:** To use the server-side pipeline for for processing grad-meh exports into map tiles (GDAL, tippecanoe), choose `ghcr.io/ocap2/web:full` instead of `:latest`.
+> **Map tools:** To use the server-side pipeline for for processing grad_meh exports into map tiles (GDAL, tippecanoe), choose `ghcr.io/ocap2/web:full` instead of `:latest`.
 
 ### Start the server
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -223,7 +223,7 @@ Set `OCAP_SECRET` to the same value as `api.apiKey` in the extension's `ocap_rec
 
 Any `setting.json` field can be set as an environment variable using the `OCAP_` prefix with nested keys uppercased and concatenated (e.g. `auth.steamApiKey` → `OCAP_AUTH_STEAMAPIKEY`). See [Configuration Reference](configuration.md).
 
-> **Map tools:** To use the server-side pipeline for for processing grad_meh exports into map tiles (GDAL, tippecanoe), choose `ghcr.io/ocap2/web:full` instead of `:latest`.
+> **Map tools:** To use the server-side pipeline for processing grad_meh exports into map tiles (GDAL, tippecanoe), choose `ghcr.io/ocap2/web:full` instead of `:latest`.
 
 ### Start the server
 


### PR DESCRIPTION
Makes a few adjustments to the documentation based on issues I had setting up OCAP for the first time:

1. Setting `prefixURL` and `serverUrl` to match accordingly
2. Setting `OCAP_AUTH_ADMINSTEAMIDS` env var to a comma-separated list of IDs
3. Needing to (not rather, not needing to) upload map tiles to the OCAP webserver
4. The difference between uploading map tiles from Google Drive / archives.ocap2.com versus using `ghcr.io/ocap2/web:full` to process grad_meh exports into map tiles

Hopefully this saves a bit of headache for the next person setting up OCAP :)